### PR TITLE
Change ignored directories for erlenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /plugins
 /shims
-/version
-/versions
+/release
+/releases
 /sources


### PR DESCRIPTION
Just because `erlenv` uses `release(s)` instead of `version(s)`.
