### PR TITLE
[fish] fix setenv error: Too many arguments

### DIFF
--- a/libexec/erlenv-init
+++ b/libexec/erlenv-init
@@ -92,7 +92,7 @@ mkdir -p "${ERLENV_ROOT}/"{shims,releases}
 if [[ ":${PATH}:" != *:"${ERLENV_ROOT}/shims":* ]]; then
   case "$shell" in
   fish )
-    echo "setenv PATH '${ERLENV_ROOT}/shims' \$PATH"
+    echo "set -gx PATH '${ERLENV_ROOT}/shims' \$PATH"
   ;;
   * )
     echo 'export PATH="'${ERLENV_ROOT}'/shims:${PATH}"'

--- a/test/init.bats
+++ b/test/init.bats
@@ -48,7 +48,7 @@ load test_helper
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin"
   SHELL=/usr/bin/fish run erlenv-init -
   assert_success
-  assert_line 0 "setenv PATH '${ERLENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${ERLENV_ROOT}/shims' \$PATH"
 }
 
 @test "doesn't add shims to PATH more than once" {


### PR DESCRIPTION
Hi.
In the case of using fish-shell, the error was occurred because `erlenv init -` was broken.